### PR TITLE
Add Dexie-backed kanban board UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,17 @@
       "name": "test",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.1",
+        "dexie": "^4.2.0",
+        "dexie-react-hooks": "^4.2.0",
         "react": "^19.1.1",
+        "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@types/react": "^19.1.13",
+        "@types/react-beautiful-dnd": "^13.1.8",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
         "autoprefixer": "^10.4.20",
@@ -273,6 +278,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1455,6 +1469,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1466,10 +1492,19 @@
       "version": "19.1.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-beautiful-dnd": {
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.8.tgz",
+      "integrity": "sha512-E3TyFsro9pQuK4r8S/OL6G99eq7p8v29sX0PM7oT8Z+PJfZvSQTx4zTQbUJ+QZXioAF0e7TGBEcA1XhYhCweyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -1480,6 +1515,18 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2100,6 +2147,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2159,6 +2215,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2176,7 +2241,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2203,6 +2267,23 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dexie-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "dexie": ">=4.2.0-alpha.1 <5.0.0",
+        "react": ">=16"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2776,6 +2857,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2922,7 +3018,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3052,6 +3147,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3061,6 +3168,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3185,7 +3298,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3528,6 +3640,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3559,6 +3688,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -3566,6 +3701,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -3579,6 +3768,12 @@
       "peerDependencies": {
         "react": "^19.1.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3611,6 +3806,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/resolve": {
@@ -4009,6 +4213,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
+    "dexie": "^4.2.0",
+    "dexie-react-hooks": "^4.2.0",
     "react": "^19.1.1",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@types/react": "^19.1.13",
+    "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
     "autoprefixer": "^10.4.20",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,71 +1,392 @@
-import { useState } from 'react'
-
-const resources = [
-  {
-    href: 'https://vite.dev/guide/',
-    title: 'Vite documentation',
-    description: 'Learn how Vite enables lightning-fast development builds.',
-  },
-  {
-    href: 'https://react.dev/learn',
-    title: 'React documentation',
-    description: 'Review the modern React patterns used in this starter.',
-  },
-  {
-    href: 'https://tailwindcss.com/docs/guides/vite',
-    title: 'Tailwind CSS + Vite guide',
-    description: 'Explore Tailwind utilities and best practices for styling.',
-  },
-]
+import type { FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  DragDropContext,
+  Draggable,
+  Droppable,
+  type DraggableProvided,
+  type DraggableStateSnapshot,
+  type DropResult,
+  type DroppableProvided,
+  type DroppableStateSnapshot,
+} from 'react-beautiful-dnd'
+import { useLiveQuery } from 'dexie-react-hooks'
+import clsx from 'clsx'
+import {
+  type Column,
+  type Task,
+  createColumn,
+  createProjectTemplate,
+  createTask,
+  db,
+} from './db'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const projects = useLiveQuery(() => db.projects.orderBy('createdAt').toArray(), [])
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
+  const [projectName, setProjectName] = useState('')
+
+  useEffect(() => {
+    if (projects && projects.length > 0 && !selectedProjectId) {
+      setSelectedProjectId(projects[0].id)
+    }
+  }, [projects, selectedProjectId])
+
+  const selectedProject = useMemo(
+    () => projects?.find((project) => project.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  )
+
+  const handleCreateProject = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = projectName.trim()
+      if (!trimmed) return
+
+      const project = createProjectTemplate(trimmed)
+      await db.projects.put(project)
+      setProjectName('')
+      setSelectedProjectId(project.id)
+    },
+    [projectName],
+  )
+
+  const handleAddColumn = useCallback(async () => {
+    if (!selectedProject) return
+    const newColumn = createColumn('New state')
+    const nextColumns = { ...selectedProject.columns, [newColumn.id]: newColumn }
+    const nextOrder = [...selectedProject.columnOrder, newColumn.id]
+    await db.projects.update(selectedProject.id, {
+      columns: nextColumns,
+      columnOrder: nextOrder,
+    })
+  }, [selectedProject])
+
+  const handleRenameColumn = useCallback(
+    async (columnId: string, title: string) => {
+      if (!selectedProject) return
+      const trimmed = title.trim() || 'Untitled'
+      const current = selectedProject.columns[columnId]
+      if (!current) return
+      if (current.title === trimmed) return
+
+      await db.projects.update(selectedProject.id, {
+        columns: {
+          ...selectedProject.columns,
+          [columnId]: { ...current, title: trimmed },
+        },
+      })
+    },
+    [selectedProject],
+  )
+
+  const handleAddTask = useCallback(
+    async (columnId: string, content: string) => {
+      if (!selectedProject) return
+      const column = selectedProject.columns[columnId]
+      if (!column) return
+      const trimmed = content.trim()
+      if (!trimmed) return
+
+      const task = createTask(trimmed, columnId)
+      const nextTasks: Record<string, Task> = {
+        ...selectedProject.tasks,
+        [task.id]: task,
+      }
+      const nextColumns: Record<string, Column> = {
+        ...selectedProject.columns,
+        [columnId]: { ...column, taskIds: [...column.taskIds, task.id] },
+      }
+
+      await db.projects.update(selectedProject.id, {
+        tasks: nextTasks,
+        columns: nextColumns,
+      })
+    },
+    [selectedProject],
+  )
+
+  const handleDragEnd = useCallback(
+    async (result: DropResult) => {
+      if (!selectedProject) return
+      const { destination, source, draggableId, type } = result
+
+      if (!destination) {
+        return
+      }
+
+      if (type === 'column') {
+        const order = Array.from(selectedProject.columnOrder)
+        order.splice(source.index, 1)
+        order.splice(destination.index, 0, draggableId)
+        await db.projects.update(selectedProject.id, { columnOrder: order })
+        return
+      }
+
+      const startColumn = selectedProject.columns[source.droppableId]
+      const finishColumn = selectedProject.columns[destination.droppableId]
+      if (!startColumn || !finishColumn) return
+
+      if (startColumn === finishColumn) {
+        const nextTaskIds = Array.from(startColumn.taskIds)
+        nextTaskIds.splice(source.index, 1)
+        nextTaskIds.splice(destination.index, 0, draggableId)
+
+        await db.projects.update(selectedProject.id, {
+          columns: {
+            ...selectedProject.columns,
+            [startColumn.id]: { ...startColumn, taskIds: nextTaskIds },
+          },
+        })
+        return
+      }
+
+      const startTaskIds = Array.from(startColumn.taskIds)
+      startTaskIds.splice(source.index, 1)
+      const finishTaskIds = Array.from(finishColumn.taskIds)
+      finishTaskIds.splice(destination.index, 0, draggableId)
+
+      const task = selectedProject.tasks[draggableId]
+      const updatedTask: Task | undefined = task
+        ? { ...task, columnId: finishColumn.id }
+        : undefined
+
+      await db.projects.update(selectedProject.id, {
+        columns: {
+          ...selectedProject.columns,
+          [startColumn.id]: { ...startColumn, taskIds: startTaskIds },
+          [finishColumn.id]: { ...finishColumn, taskIds: finishTaskIds },
+        },
+        ...(updatedTask && {
+          tasks: {
+            ...selectedProject.tasks,
+            [draggableId]: updatedTask,
+          },
+        }),
+      })
+    },
+    [selectedProject],
+  )
 
   return (
-    <main className="flex min-h-screen w-full flex-col items-center justify-center px-4 py-16">
-      <div className="w-full max-w-3xl space-y-10 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center shadow-[0_20px_50px_rgba(15,23,42,0.45)] backdrop-blur">
-        <div className="space-y-4">
-          <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
-            Ready to build
-          </span>
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
-            React, Vite & Tailwind out of the box
-          </h1>
-          <p className="mx-auto max-w-xl text-base text-slate-300 sm:text-lg">
-            Start shipping features faster with a development environment that comes
-            preconfigured with TypeScript, hot module replacement, and utility-first styles.
+    <div className="flex min-h-screen bg-slate-950 text-slate-100">
+      <aside className="flex w-full max-w-xs flex-col gap-6 border-r border-slate-800/60 bg-slate-950/70 p-6">
+        <div>
+          <h1 className="text-lg font-semibold text-slate-50">Projects</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            Create a project to start organising tasks on its own kanban board.
           </p>
         </div>
 
-        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <form className="space-y-3" onSubmit={handleCreateProject}>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="project-name">
+              Project name
+            </label>
+            <input
+              id="project-name"
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              placeholder="e.g. Marketing sprint"
+              value={projectName}
+              onChange={(event) => setProjectName(event.target.value)}
+              type="text"
+            />
+          </div>
           <button
-            className="rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
-            onClick={() => setCount((value) => value + 1)}
-            type="button"
+            className="w-full rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/70"
+            type="submit"
           >
-            Count is {count}
+            Create project
           </button>
-          <span className="text-sm font-medium text-slate-400">
-            Tailwind classes update instantly thanks to Vite&apos;s HMR
-          </span>
-        </div>
+        </form>
 
-        <ul className="grid gap-4 text-left sm:grid-cols-3">
-          {resources.map((resource) => (
-            <li
-              key={resource.title}
-              className="group relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 transition hover:border-indigo-400/70 hover:bg-slate-900/80"
+        <div className="flex-1 space-y-2 overflow-y-auto">
+          {projects?.map((project) => (
+            <button
+              key={project.id}
+              onClick={() => setSelectedProjectId(project.id)}
+              className={clsx(
+                'w-full rounded-md px-3 py-2 text-left text-sm font-medium transition',
+                selectedProjectId === project.id
+                  ? 'bg-indigo-500/20 text-indigo-200'
+                  : 'bg-slate-900 text-slate-200 hover:bg-slate-800',
+              )}
+              type="button"
             >
-              <div className="absolute inset-0 bg-gradient-to-br from-indigo-400/0 via-indigo-400/0 to-indigo-400/10 opacity-0 transition group-hover:opacity-100" />
-              <a className="relative flex h-full flex-col gap-2" href={resource.href} target="_blank" rel="noreferrer">
-                <span className="text-sm font-semibold text-indigo-300">{resource.title}</span>
-                <p className="text-sm leading-relaxed text-slate-300">{resource.description}</p>
-              </a>
-            </li>
+              <span className="block truncate">{project.name}</span>
+              <span className="mt-1 block text-xs font-normal text-slate-400">
+                {new Date(project.createdAt).toLocaleDateString()}
+              </span>
+            </button>
           ))}
-        </ul>
-      </div>
-    </main>
+          {projects?.length === 0 && (
+            <p className="text-sm text-slate-500">No projects yet. Create one above to begin.</p>
+          )}
+        </div>
+      </aside>
+
+      <section className="flex-1 overflow-hidden">
+        {selectedProject ? (
+          <div className="flex h-full flex-col">
+            <header className="flex items-center justify-between border-b border-slate-800/60 bg-slate-950/60 px-8 py-5">
+              <div>
+                <h2 className="text-2xl font-semibold text-slate-50">{selectedProject.name}</h2>
+                <p className="text-sm text-slate-400">Drag tasks between states to keep work in sync.</p>
+              </div>
+              <button
+                className="rounded-md border border-indigo-400/60 px-3 py-2 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/10"
+                onClick={handleAddColumn}
+                type="button"
+              >
+                Add state
+              </button>
+            </header>
+
+            <div className="flex-1 overflow-x-auto">
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <Droppable droppableId="board" direction="horizontal" type="column">
+                  {(provided: DroppableProvided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="flex h-full min-h-0 w-full gap-4 overflow-x-auto px-8 py-6"
+                    >
+                      {selectedProject.columnOrder.map((columnId, index) => {
+                        const column = selectedProject.columns[columnId]
+                        if (!column) return null
+                        const tasks = column.taskIds.map((taskId) => selectedProject.tasks[taskId]).filter(Boolean)
+
+                        return (
+                          <ColumnCard
+                            key={column.id}
+                            column={column}
+                            index={index}
+                            onAddTask={handleAddTask}
+                            onRenameColumn={handleRenameColumn}
+                            tasks={tasks as Task[]}
+                          />
+                        )
+                      })}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-center text-slate-400">
+            <h2 className="text-xl font-semibold text-slate-200">Select or create a project</h2>
+            <p className="max-w-md text-sm">
+              Choose a project from the left or create a new one to manage its kanban board. Every project stores its own states
+              and tasks locally with IndexedDB.
+            </p>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+type ColumnCardProps = {
+  column: Column
+  index: number
+  onRenameColumn: (columnId: string, title: string) => void
+  onAddTask: (columnId: string, content: string) => void
+  tasks: Task[]
+}
+
+function ColumnCard({ column, index, onRenameColumn, onAddTask, tasks }: ColumnCardProps) {
+  const [title, setTitle] = useState(column.title)
+  const [newTask, setNewTask] = useState('')
+
+  useEffect(() => {
+    setTitle(column.title)
+  }, [column.title])
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = newTask.trim()
+      if (!trimmed) return
+      onAddTask(column.id, trimmed)
+      setNewTask('')
+    },
+    [column.id, newTask, onAddTask],
+  )
+
+  return (
+    <Draggable draggableId={column.id} index={index}>
+      {(provided: DraggableProvided) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          className="flex h-full w-72 flex-shrink-0 flex-col rounded-xl bg-slate-900/80 shadow-lg shadow-slate-950/40"
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-slate-800/60 px-4 py-3">
+            <input
+              {...provided.dragHandleProps}
+              className="w-full rounded-md bg-transparent text-sm font-semibold text-slate-100 focus:border focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              onBlur={() => onRenameColumn(column.id, title)}
+            />
+          </div>
+
+          <Droppable droppableId={column.id} type="task">
+            {(dropProvided: DroppableProvided, snapshot: DroppableStateSnapshot) => (
+              <div
+                ref={dropProvided.innerRef}
+                {...dropProvided.droppableProps}
+                className={clsx(
+                  'flex-1 space-y-3 overflow-y-auto px-4 py-4',
+                  snapshot.isDraggingOver ? 'bg-slate-800/40' : 'bg-transparent',
+                )}
+              >
+                {tasks.map((task, taskIndex) => (
+                  <Draggable draggableId={task.id} index={taskIndex} key={task.id}>
+                    {(taskProvided: DraggableProvided, taskSnapshot: DraggableStateSnapshot) => (
+                      <div
+                        ref={taskProvided.innerRef}
+                        {...taskProvided.draggableProps}
+                        {...taskProvided.dragHandleProps}
+                        className={clsx(
+                          'rounded-lg border border-slate-800/60 bg-slate-900 px-3 py-3 text-sm text-slate-200 shadow-sm transition',
+                          taskSnapshot.isDragging && 'border-indigo-400/60 bg-slate-900/80 shadow-lg shadow-indigo-500/20',
+                        )}
+                      >
+                        {task.content}
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+                {dropProvided.placeholder}
+              </div>
+            )}
+          </Droppable>
+
+          <form onSubmit={handleSubmit} className="border-t border-slate-800/60 px-4 py-3">
+            <label className="sr-only" htmlFor={`new-task-${column.id}`}>
+              Add task
+            </label>
+            <input
+              id={`new-task-${column.id}`}
+              className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              placeholder="Add new task"
+              value={newTask}
+              onChange={(event) => setNewTask(event.target.value)}
+              type="text"
+            />
+            <button
+              className="mt-2 w-full rounded-md bg-slate-800 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-slate-700"
+              type="submit"
+            >
+              Add task
+            </button>
+          </form>
+        </div>
+      )}
+    </Draggable>
   )
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,74 @@
+import Dexie, { type Table } from 'dexie'
+
+export interface Task {
+  id: string
+  content: string
+  columnId: string
+  createdAt: number
+}
+
+export interface Column {
+  id: string
+  title: string
+  taskIds: string[]
+  createdAt: number
+}
+
+export interface Project {
+  id: string
+  name: string
+  createdAt: number
+  columnOrder: string[]
+  columns: Record<string, Column>
+  tasks: Record<string, Task>
+}
+
+class KanbanDatabase extends Dexie {
+  projects!: Table<Project, string>
+
+  constructor() {
+    super('kanban-workspace')
+    this.version(1).stores({
+      projects: 'id, name, createdAt',
+    })
+  }
+}
+
+export const db = new KanbanDatabase()
+
+export function createColumn(title: string): Column {
+  return {
+    id: crypto.randomUUID(),
+    title,
+    taskIds: [],
+    createdAt: Date.now(),
+  }
+}
+
+export function createTask(content: string, columnId: string): Task {
+  return {
+    id: crypto.randomUUID(),
+    content,
+    columnId,
+    createdAt: Date.now(),
+  }
+}
+
+export function createProjectTemplate(name: string): Project {
+  const todo = createColumn('To do')
+  const doing = createColumn('In progress')
+  const done = createColumn('Done')
+
+  return {
+    id: crypto.randomUUID(),
+    name,
+    createdAt: Date.now(),
+    columnOrder: [todo.id, doing.id, done.id],
+    columns: {
+      [todo.id]: todo,
+      [doing.id]: doing,
+      [done.id]: done,
+    },
+    tasks: {},
+  }
+}


### PR DESCRIPTION
## Summary
- replace the starter view with a kanban workspace that uses react-beautiful-dnd for drag and drop
- persist projects, states, and tasks in IndexedDB via Dexie with defaults for new projects
- add controls to create projects, rename columns, and add tasks within each project board

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c761369c83318691a782a15e24a4