### PR TITLE
Add Dexie-powered task board

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "test",
       "version": "0.0.0",
       "dependencies": {
+        "dexie": "^4.2.0",
+        "dexie-react-hooks": "^4.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1466,7 +1468,6 @@
       "version": "19.1.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2176,7 +2177,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2203,6 +2203,23 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dexie-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "dexie": ">=4.2.0-alpha.1 <5.0.0",
+        "react": ">=16"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "dexie": "^4.2.0",
+    "dexie-react-hooks": "^4.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,69 +1,291 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db, type BoardColumnKey, type Task } from './db'
 
-const resources = [
+const columns: { key: BoardColumnKey; title: string; hint: string }[] = [
   {
-    href: 'https://vite.dev/guide/',
-    title: 'Vite documentation',
-    description: 'Learn how Vite enables lightning-fast development builds.',
+    key: 'backlog',
+    title: 'Backlog',
+    hint: 'Ideas and work that still needs prioritisation.',
   },
   {
-    href: 'https://react.dev/learn',
-    title: 'React documentation',
-    description: 'Review the modern React patterns used in this starter.',
+    key: 'inProgress',
+    title: 'In progress',
+    hint: 'Work being actively tackled right now.',
   },
   {
-    href: 'https://tailwindcss.com/docs/guides/vite',
-    title: 'Tailwind CSS + Vite guide',
-    description: 'Explore Tailwind utilities and best practices for styling.',
+    key: 'review',
+    title: 'Review',
+    hint: 'Items waiting for QA or feedback.',
+  },
+  {
+    key: 'done',
+    title: 'Done',
+    hint: 'Shipped or completed items to celebrate.',
   },
 ]
 
-function App() {
-  const [count, setCount] = useState(0)
+const statusLabels: Record<BoardColumnKey, string> = columns.reduce(
+  (acc, column) => {
+    acc[column.key] = column.title
+    return acc
+  },
+  {} as Record<BoardColumnKey, string>,
+)
+
+function formatTimestamp(timestamp: number) {
+  const date = new Date(timestamp)
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+async function handleAddTask(status: BoardColumnKey) {
+  const now = Date.now()
+  await db.tasks.add({
+    title: 'New task',
+    description: '',
+    status,
+    createdAt: now,
+    updatedAt: now,
+  })
+}
+
+async function handleDeleteTask(taskId: number | undefined) {
+  if (!taskId) return
+  await db.tasks.delete(taskId)
+}
+
+type TaskCardProps = {
+  task: Task
+}
+
+function TaskCard({ task }: TaskCardProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [formState, setFormState] = useState({
+    title: task.title,
+    description: task.description,
+    status: task.status,
+  })
+
+  useEffect(() => {
+    setFormState({
+      title: task.title,
+      description: task.description,
+      status: task.status,
+    })
+  }, [task.description, task.status, task.title])
+
+  async function saveChanges() {
+    if (!task.id) return
+    const trimmedTitle = formState.title.trim()
+    await db.tasks.update(task.id, {
+      title: trimmedTitle.length ? trimmedTitle : 'Untitled task',
+      description: formState.description,
+      status: formState.status,
+      updatedAt: Date.now(),
+    })
+    setIsEditing(false)
+  }
 
   return (
-    <main className="flex min-h-screen w-full flex-col items-center justify-center px-4 py-16">
-      <div className="w-full max-w-3xl space-y-10 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center shadow-[0_20px_50px_rgba(15,23,42,0.45)] backdrop-blur">
-        <div className="space-y-4">
-          <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
-            Ready to build
+    <article className="group rounded-xl border border-slate-700/60 bg-slate-900/80 p-4 shadow-sm shadow-slate-900 transition hover:border-indigo-500/60">
+      {isEditing ? (
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void saveChanges()
+          }}
+        >
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`title-${task.id}`}>
+              Title
+            </label>
+            <input
+              id={`title-${task.id}`}
+              className="w-full rounded-lg border border-slate-700/70 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/40"
+              onChange={(event) => setFormState((state) => ({ ...state, title: event.target.value }))}
+              value={formState.title}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`description-${task.id}`}>
+              Description
+            </label>
+            <textarea
+              id={`description-${task.id}`}
+              className="min-h-[96px] w-full rounded-lg border border-slate-700/70 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/40"
+              onChange={(event) => setFormState((state) => ({ ...state, description: event.target.value }))}
+              value={formState.description}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor={`status-${task.id}`}>
+              Status
+            </label>
+            <select
+              id={`status-${task.id}`}
+              className="w-full rounded-lg border border-slate-700/70 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/40"
+              onChange={(event) =>
+                setFormState((state) => ({ ...state, status: event.target.value as BoardColumnKey }))
+              }
+              value={formState.status}
+            >
+              {columns.map((column) => (
+                <option key={column.key} value={column.key}>
+                  {column.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              className="rounded-lg border border-transparent px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:text-slate-100"
+              onClick={() => {
+                setIsEditing(false)
+                setFormState({
+                  title: task.title,
+                  description: task.description,
+                  status: task.status,
+                })
+              }}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="rounded-lg bg-indigo-500 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-indigo-400"
+              type="submit"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-slate-100">{task.title || 'Untitled task'}</h3>
+              <p className="text-xs font-medium uppercase tracking-wide text-indigo-300">{statusLabels[task.status]}</p>
+            </div>
+            <div className="flex items-center gap-1 opacity-0 transition group-hover:opacity-100">
+              <button
+                className="rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-300 transition hover:bg-indigo-500/10 hover:text-indigo-200"
+                onClick={() => setIsEditing(true)}
+                type="button"
+              >
+                Edit
+              </button>
+              <button
+                className="rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide text-rose-300 transition hover:bg-rose-500/10 hover:text-rose-200"
+                onClick={() => handleDeleteTask(task.id)}
+                type="button"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+          {task.description ? (
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-slate-300">{task.description}</p>
+          ) : (
+            <p className="text-sm italic text-slate-500">No description yet. Click edit to add more details.</p>
+          )}
+          <p className="text-xs text-slate-500">Updated {formatTimestamp(task.updatedAt)}</p>
+        </div>
+      )}
+    </article>
+  )
+}
+
+type TaskColumnProps = {
+  column: (typeof columns)[number]
+  tasks: Task[]
+}
+
+function TaskColumn({ column, tasks }: TaskColumnProps) {
+  const sortedTasks = useMemo(
+    () =>
+      [...tasks].sort((a, b) => {
+        if (a.createdAt === b.createdAt) {
+          return (a.id ?? 0) - (b.id ?? 0)
+        }
+        return a.createdAt - b.createdAt
+      }),
+    [tasks],
+  )
+
+  return (
+    <section className="flex h-full min-h-[540px] w-full flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_30px_60px_rgba(15,23,42,0.55)]">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-slate-100">{column.title}</h2>
+        <p className="text-sm text-slate-400">{column.hint}</p>
+      </header>
+      <div className="space-y-3 overflow-y-auto pr-1">
+        {sortedTasks.map((task) => (
+          <TaskCard key={task.id} task={task} />
+        ))}
+        {sortedTasks.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-slate-700/70 bg-slate-900/40 p-4 text-sm text-slate-500">
+            No tasks yet. Use the button below to add your first card.
+          </p>
+        ) : null}
+      </div>
+      <button
+        className="mt-auto flex items-center justify-center gap-2 rounded-xl border border-indigo-500/40 bg-indigo-500/10 px-4 py-2 text-sm font-semibold text-indigo-200 transition hover:border-indigo-400 hover:bg-indigo-500/20"
+        onClick={() => {
+          void handleAddTask(column.key)
+        }}
+        type="button"
+      >
+        + Add task
+      </button>
+    </section>
+  )
+}
+
+function App() {
+  const tasks = useLiveQuery(async () => db.tasks.toArray(), [], [])
+
+  const tasksByStatus = useMemo(() => {
+    const grouped: Record<BoardColumnKey, Task[]> = {
+      backlog: [],
+      inProgress: [],
+      review: [],
+      done: [],
+    }
+
+    if (!tasks) {
+      return grouped
+    }
+
+    for (const task of tasks) {
+      grouped[task.status]?.push(task)
+    }
+
+    return grouped
+  }, [tasks])
+
+  return (
+    <main className="min-h-screen w-full bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-10 text-slate-50">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <div className="space-y-4 text-center">
+          <span className="inline-flex items-center justify-center gap-2 rounded-full bg-indigo-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-indigo-300">
+            Plan and track
           </span>
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
-            React, Vite & Tailwind out of the box
-          </h1>
-          <p className="mx-auto max-w-xl text-base text-slate-300 sm:text-lg">
-            Start shipping features faster with a development environment that comes
-            preconfigured with TypeScript, hot module replacement, and utility-first styles.
+          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">Your personal task board</h1>
+          <p className="mx-auto max-w-2xl text-base text-slate-300 sm:text-lg">
+            Create and edit cards in each column, and everything is saved locally thanks to IndexedDB powered by Dexie. Use the add
+            task buttons at the bottom of each list to grow your backlog just like you would in Trello.
           </p>
         </div>
 
-        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <button
-            className="rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
-            onClick={() => setCount((value) => value + 1)}
-            type="button"
-          >
-            Count is {count}
-          </button>
-          <span className="text-sm font-medium text-slate-400">
-            Tailwind classes update instantly thanks to Vite&apos;s HMR
-          </span>
-        </div>
-
-        <ul className="grid gap-4 text-left sm:grid-cols-3">
-          {resources.map((resource) => (
-            <li
-              key={resource.title}
-              className="group relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 transition hover:border-indigo-400/70 hover:bg-slate-900/80"
-            >
-              <div className="absolute inset-0 bg-gradient-to-br from-indigo-400/0 via-indigo-400/0 to-indigo-400/10 opacity-0 transition group-hover:opacity-100" />
-              <a className="relative flex h-full flex-col gap-2" href={resource.href} target="_blank" rel="noreferrer">
-                <span className="text-sm font-semibold text-indigo-300">{resource.title}</span>
-                <p className="text-sm leading-relaxed text-slate-300">{resource.description}</p>
-              </a>
-            </li>
+        <div className="grid gap-6 lg:grid-cols-4">
+          {columns.map((column) => (
+            <TaskColumn key={column.key} column={column} tasks={tasksByStatus[column.key]} />
           ))}
-        </ul>
+        </div>
       </div>
     </main>
   )

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,25 @@
+import Dexie, { type Table } from 'dexie'
+
+export type BoardColumnKey = 'backlog' | 'inProgress' | 'review' | 'done'
+
+export interface Task {
+  id?: number
+  title: string
+  description: string
+  status: BoardColumnKey
+  createdAt: number
+  updatedAt: number
+}
+
+class TaskDatabase extends Dexie {
+  tasks!: Table<Task, number>
+
+  constructor() {
+    super('task-board')
+    this.version(1).stores({
+      tasks: '++id, status, title, createdAt',
+    })
+  }
+}
+
+export const db = new TaskDatabase()


### PR DESCRIPTION
## Summary
- replace the starter landing page with a four-column task board styled like Trello
- persist cards locally using a Dexie-powered IndexedDB store and allow inline editing per task
- add per-column buttons to quickly create new cards in the corresponding workflow state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d6081de08331abe4b4dc731c5ade