### PR TITLE
Add router-driven page structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -2144,6 +2145,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3590,6 +3600,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3736,6 +3784,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,71 +1,47 @@
-import { useState } from 'react'
+import { NavLink, Outlet } from 'react-router-dom'
 
-const resources = [
-  {
-    href: 'https://vite.dev/guide/',
-    title: 'Vite documentation',
-    description: 'Learn how Vite enables lightning-fast development builds.',
-  },
-  {
-    href: 'https://react.dev/learn',
-    title: 'React documentation',
-    description: 'Review the modern React patterns used in this starter.',
-  },
-  {
-    href: 'https://tailwindcss.com/docs/guides/vite',
-    title: 'Tailwind CSS + Vite guide',
-    description: 'Explore Tailwind utilities and best practices for styling.',
-  },
-]
-
-function App() {
-  const [count, setCount] = useState(0)
-
+const App = () => {
   return (
-    <main className="flex min-h-screen w-full flex-col items-center justify-center px-4 py-16">
-      <div className="w-full max-w-3xl space-y-10 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center shadow-[0_20px_50px_rgba(15,23,42,0.45)] backdrop-blur">
-        <div className="space-y-4">
-          <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
-            Ready to build
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b border-slate-800/60 bg-slate-950/60 backdrop-blur">
+        <nav className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-4">
+          <span className="text-lg font-semibold tracking-tight text-slate-100">
+            React + Vite + Tailwind
           </span>
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
-            React, Vite & Tailwind out of the box
-          </h1>
-          <p className="mx-auto max-w-xl text-base text-slate-300 sm:text-lg">
-            Start shipping features faster with a development environment that comes
-            preconfigured with TypeScript, hot module replacement, and utility-first styles.
-          </p>
-        </div>
-
-        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <button
-            className="rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
-            onClick={() => setCount((value) => value + 1)}
-            type="button"
-          >
-            Count is {count}
-          </button>
-          <span className="text-sm font-medium text-slate-400">
-            Tailwind classes update instantly thanks to Vite&apos;s HMR
-          </span>
-        </div>
-
-        <ul className="grid gap-4 text-left sm:grid-cols-3">
-          {resources.map((resource) => (
-            <li
-              key={resource.title}
-              className="group relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 transition hover:border-indigo-400/70 hover:bg-slate-900/80"
+          <div className="flex items-center gap-3 text-sm font-medium text-slate-300">
+            <NavLink
+              to="/"
+              className={({ isActive }) =>
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-indigo-500 text-white shadow-lg shadow-indigo-500/30'
+                    : 'hover:bg-slate-800/70 hover:text-slate-100'
+                }`
+              }
+              end
             >
-              <div className="absolute inset-0 bg-gradient-to-br from-indigo-400/0 via-indigo-400/0 to-indigo-400/10 opacity-0 transition group-hover:opacity-100" />
-              <a className="relative flex h-full flex-col gap-2" href={resource.href} target="_blank" rel="noreferrer">
-                <span className="text-sm font-semibold text-indigo-300">{resource.title}</span>
-                <p className="text-sm leading-relaxed text-slate-300">{resource.description}</p>
-              </a>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </main>
+              Home
+            </NavLink>
+            <NavLink
+              to="/resources"
+              className={({ isActive }) =>
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-indigo-500 text-white shadow-lg shadow-indigo-500/30'
+                    : 'hover:bg-slate-800/70 hover:text-slate-100'
+                }`
+              }
+            >
+              Resources
+            </NavLink>
+          </div>
+        </nav>
+      </header>
+
+      <main className="flex flex-1 justify-center">
+        <Outlet />
+      </main>
+    </div>
   )
 }
 

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -1,0 +1,17 @@
+export const resources = [
+  {
+    href: 'https://vite.dev/guide/',
+    title: 'Vite documentation',
+    description: 'Learn how Vite enables lightning-fast development builds.',
+  },
+  {
+    href: 'https://react.dev/learn',
+    title: 'React documentation',
+    description: 'Review the modern React patterns used in this starter.',
+  },
+  {
+    href: 'https://tailwindcss.com/docs/guides/vite',
+    title: 'Tailwind CSS + Vite guide',
+    description: 'Explore Tailwind utilities and best practices for styling.',
+  },
+]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router-dom'
 import './index.css'
-import App from './App.tsx'
+import { router } from './router.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+const Home = () => {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="flex min-h-full w-full flex-col items-center justify-center px-4 py-16">
+      <div className="w-full max-w-3xl space-y-10 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center shadow-[0_20px_50px_rgba(15,23,42,0.45)] backdrop-blur">
+        <div className="space-y-4">
+          <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
+            Ready to build
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
+            React, Vite & Tailwind out of the box
+          </h1>
+          <p className="mx-auto max-w-xl text-base text-slate-300 sm:text-lg">
+            Start shipping features faster with a development environment that comes
+            preconfigured with TypeScript, hot module replacement, and utility-first styles.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <button
+            className="rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
+            onClick={() => setCount((value) => value + 1)}
+            type="button"
+          >
+            Count is {count}
+          </button>
+          <span className="text-sm font-medium text-slate-400">
+            Tailwind classes update instantly thanks to Vite&apos;s HMR
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Home

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+
+const NotFound = () => {
+  return (
+    <div className="flex min-h-full w-full flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="space-y-6">
+        <span className="text-7xl font-bold text-indigo-400">404</span>
+        <h1 className="text-3xl font-semibold text-slate-100">Page not found</h1>
+        <p className="mx-auto max-w-md text-sm text-slate-400">
+          The page you are looking for doesn&apos;t exist or has been moved. Use the navigation to get back on track.
+        </p>
+        <Link
+          className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400"
+          to="/"
+        >
+          Back to home
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default NotFound

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1,0 +1,38 @@
+import { resources } from '../data/resources'
+
+const Resources = () => {
+  return (
+    <div className="flex min-h-full w-full flex-col items-center justify-center px-4 py-16">
+      <div className="w-full max-w-4xl space-y-10 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center shadow-[0_20px_50px_rgba(15,23,42,0.45)] backdrop-blur">
+        <div className="space-y-4">
+          <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
+            Dive deeper
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl">
+            Level up with curated docs
+          </h1>
+          <p className="mx-auto max-w-2xl text-base text-slate-300 sm:text-lg">
+            Explore guides for Vite, React, and Tailwind to keep building incredible experiences with this starter kit.
+          </p>
+        </div>
+
+        <ul className="grid gap-4 text-left sm:grid-cols-3">
+          {resources.map((resource) => (
+            <li
+              key={resource.title}
+              className="group relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 transition hover:border-indigo-400/70 hover:bg-slate-900/80"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-indigo-400/0 via-indigo-400/0 to-indigo-400/10 opacity-0 transition group-hover:opacity-100" />
+              <a className="relative flex h-full flex-col gap-2" href={resource.href} target="_blank" rel="noreferrer">
+                <span className="text-sm font-semibold text-indigo-300">{resource.title}</span>
+                <p className="text-sm leading-relaxed text-slate-300">{resource.description}</p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default Resources

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,26 @@
+import { createBrowserRouter } from 'react-router-dom'
+import App from './App.tsx'
+import Home from './pages/Home.tsx'
+import NotFound from './pages/NotFound.tsx'
+import Resources from './pages/Resources.tsx'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />, 
+    children: [
+      {
+        index: true,
+        element: <Home />, 
+      },
+      {
+        path: 'resources',
+        element: <Resources />, 
+      },
+    ],
+  },
+  {
+    path: '*',
+    element: <NotFound />, 
+  },
+])


### PR DESCRIPTION
## Summary
- add React Router and wire the app through a shared router entry point
- move the existing landing experience into a dedicated Home page and add Resources/NotFound pages
- create a simple navigation layout and share resource data for reuse between routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d86e9d148331ad713c040908153a